### PR TITLE
Handle charset on received Content-Type

### DIFF
--- a/musicazoo/wsgi/util.py
+++ b/musicazoo/wsgi/util.py
@@ -21,8 +21,9 @@ def wsgi_control(addr,port,timeout=10):
 
     @werkzeug.Request.application
     def wsgi(request):
-        if request.headers.get('content-type') == 'text/json':
-            inp=json.loads(request.data)
+        mimetype, options = werkzeug.http.parse_options_header(request.content_type)
+        if mimetype == 'text/json':
+            inp=json.loads(request.data.decode(options.get('charset', 'utf-8')))
             try:
                 outp=query(inp)
             except Exception as e:


### PR DESCRIPTION
Firefox is appending `; charset=UTF-8` to its outgoing Content-Type.

(Actually the right Content-Type is `application/json`, not `text/json`, but I’m not going to fix that here.)